### PR TITLE
Rewrote mirror recipe to use rubygems-mirror gem instead of rsync 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ License and Author
 ==================
 
 Author:: Joshua Timberman <joshua@opscode.com>
+Author:: Pushkar Raste <praste@bloomberg.net, pushkar.raste@gmail.com>
 
 Copyright:: 2009, Opscode, Inc
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Attributes
   Default 'gems'.
 * `gem_server[:directory]` - Filesystem location for the repository,
   default is /srv/gems.
+* `gem_server[:mirror_cron_command'] - cron command to be executed to
+  download/updated mirror
+* `gem_server[:mirror_cron_expression'] - cron expression to execute
+  gem_server[:mirror_cron_command'] 
+* `gem_server['mirrorrc_contents'] - Settings for rubygems-mirror gem as per
+  https://github.com/rubygems/rubygems-mirror
+
 
 Usage
 =====

--- a/attributes/mirror.rb
+++ b/attributes/mirror.rb
@@ -1,3 +1,12 @@
 default['gem_server']['rf_virtual_host_name']  = "rubyforge.#{domain}"
 default['gem_server']['rf_virtual_host_alias'] = "rubyforge"
-default['gem_server']['rf_directory']          = "/srv/rubyforge"
+node.default['gem_server']['rf_directory']="/srv/rubyforge/mirror"
+
+default['gem_server']['mirror__cron_command']="/usr/local/bin/lockrun --lockfile=/srv/mirror.lockrun -- /bb/webops/ruby-2.0.0/embedded/bin/ruby -rrubygems/commands/mirror_command -S /bb/webops/ruby-2.0.0/embedded/bin/gem mirror &>> /srv/mirror.log"
+default['gem_server']['mirror_cron_expression']="*/5 * * * *"
+
+
+node.default['gem_server']['mirrorrc_contents']="---
+- from: http://rubygems.org
+  to: #{node['gem_server']['rf_directory']}
+  parallelism: 100"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,15 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Sets up a local gem server repository or mirror"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.0"
-recipe            "gems", "Empty, use one of the other recipes"
+version           "2.0.0"
+
+recipe            "gems", "Installs rubygems-mirror gem"
 recipe            "gems::server", "Sets up a local gem server repository"
 recipe            "gems::mirror", "Crons an rsync of rubyforge"
 depends           "apache2"
-depends           "rsync"
+
+depends           "apache2"
+depends           "lockrun"
 
 %w{ ubuntu debian }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,3 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# install rubygems-mirror gem
+gem_package "rubygems-mirror" do
+  action :install
+end

--- a/recipes/mirror.rb
+++ b/recipes/mirror.rb
@@ -18,25 +18,49 @@
 #
 # Set up a mirror for RubyForge
 
-include_recipe "rsync"
+include_recipe 'lockrun'
 
-directory node['gem_server']['directory'] do
+
+directory "#{node['gem_server']['rf_directory']}" do
   owner "root"
   group "root"
   mode "0755"
+  recursive true
 end
 
-directory "#{node['gem_server']['directory']}/gems" do
+directory "/root/.gem" do
   owner "root"
   group "root"
   mode "0755"
+  recursive true
 end
+
+file "/root/.gem/.mirrorrc" do
+  owner "root"
+  group "root"
+  mode "0755"
+  action :create
+  content "#{node.default["gem_server"]["mirrorrc_contents"]}"
+end
+
+mirror_cron_expression_parts = node.default['gem_server']['mirror_cron_expression'].split(" ")
 
 cron "mirror_rubyforge" do
-  command "rsync -av rsync://master.mirror.rubyforge.org/gems/ #{node['gem_server']['rf_directory']}/gems && gem generate_index -d #{node['gem_server']['rf_directory']}"
-  hour "2"
+  command "#{node.default['gem_server']['mirror_cron_command']}"
+  
+  minute mirror_cron_expression_parts[0]
+  hour mirror_cron_expression_parts[1]
+  day mirror_cron_expression_parts[2]
+  month mirror_cron_expression_parts[3]
+  weekday mirror_cron_expression_parts[4]
+end
+
+cron "generate_index" do
+  command "gem generate_index -d #{node['gem_server']['rf_directory']}/mirror/"
   minute "0"
 end
+
+
 
 template "#{node['apache']['dir']}/sites-available/rubyforge_mirror.conf" do
   source "gem_server.conf.erb"
@@ -50,3 +74,4 @@ template "#{node['apache']['dir']}/sites-available/rubyforge_mirror.conf" do
 end
 
 apache_site "rubyforge_mirror.conf"
+


### PR DESCRIPTION
Ruby gems are now moved to amazon s3 storage. rsync no longer works to create a mirror. Rewrote most of the mirror recipe to download gems using https://github.com/rubygems/rubygems-mirror

This fixes issues #4 , #3 , #2 
